### PR TITLE
Feat[#23] UserEntity 항목 추가

### DIFF
--- a/bokjido/src/main/java/com/projectbusan/bokjido/controller/UserController.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.projectbusan.bokjido.controller;
 
 import com.projectbusan.bokjido.dto.AuthDTO;
+import com.projectbusan.bokjido.entity.Post;
+import com.projectbusan.bokjido.entity.User;
 import com.projectbusan.bokjido.service.AuthService;
 import com.projectbusan.bokjido.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "1. 유저 페이지", description = "유저 관련 API")
 @RestController
@@ -120,10 +124,16 @@ public class UserController {
                 .build();
     }
 
-/*    // 모든 회원 조회
+    // 모든 회원 조회
     @Operation(summary = "모든 회원 조회")
-    @GetMapping("/allusers")
-    public List<User> userList() {
+    @GetMapping("/loadall")
+    public @ResponseBody ResponseEntity loadAll() {
+        List<User> userList;
 
-    }*/
+        try{
+            userList = userService.loadAll();
+        } catch(IllegalStateException e) {
+            return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+        } return new ResponseEntity(userList, HttpStatus.OK);
+    }
 }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/controller/UserController.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/controller/UserController.java
@@ -124,16 +124,25 @@ public class UserController {
                 .build();
     }
 
-    // 모든 회원 조회
+    // <<-- 모든 회원 조회
     @Operation(summary = "모든 회원 조회")
     @GetMapping("/loadall")
-    public @ResponseBody ResponseEntity loadAll() {
+    public @ResponseBody ResponseEntity getAll() {
         List<User> userList;
 
         try{
-            userList = userService.loadAll();
+            userList = userService.getAll();
         } catch(IllegalStateException e) {
             return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
         } return new ResponseEntity(userList, HttpStatus.OK);
+    }
+
+    // <<-- 해당 ID의 관심주제 조회 -->>
+    @Operation(summary = "해당 ID의 관심주제 조회")
+    @GetMapping("/load/{id}")
+    public ResponseEntity getInterestTopicById(@PathVariable("id") Long id) {
+        List<String> interestList = userService.findInterestTopic(id);
+        return ResponseEntity.ok(interestList);
+
     }
 }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
@@ -1,7 +1,6 @@
 package com.projectbusan.bokjido.dto;
 
 import com.projectbusan.bokjido.enums.HouseholdSituationCategory;
-import com.projectbusan.bokjido.enums.InterestTopicCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -54,10 +53,10 @@ public class AuthDTO {
         private HouseholdSituationCategory householdSituationCategory;
 
         @Schema(description = "관심주제", example = "PHYSICAL_HEALTH")
-        private InterestTopicCategory interestTopicCategory;
+        private String[] interestTopicCategory;
 
         @Builder
-        public SignupDto(String userid, String password, String username, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, InterestTopicCategory interestTopicCategory) {
+        public SignupDto(String userid, String password, String username, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, String[] interestTopicCategory) {
             this.userid = userid;
             this.password = password;
             this.username = username;

--- a/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
@@ -1,5 +1,7 @@
 package com.projectbusan.bokjido.dto;
 
+import com.projectbusan.bokjido.enums.HouseholdSituationCategory;
+import com.projectbusan.bokjido.enums.InterestTopicCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -10,10 +12,10 @@ public class AuthDTO {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class LoginDto {
-        @Schema(description = "아이디")
+        @Schema(description = "아이디", example = "userid")
         private String userid;
 
-        @Schema(description = "password")
+        @Schema(description = "password", example = "password")
         private String password;
 
         @Builder
@@ -36,19 +38,35 @@ public class AuthDTO {
         @Schema(description = "이름", example = "username")
         private String username;
 
+        @Schema(description = "이메일", example = "email@naver.com")
+        private String email;
+
+        @Schema(description = "연락처", example = "010-1234-5678")
+        private String phone;
+
         @Schema(description = "생년월일", example = "2000-01-01")
         private LocalDate birth;
 
         @Schema(description = "성별", example = "남")
         private String gender;
 
+        @Schema(description = "가구상황", example = "LOW_INCOME")
+        private HouseholdSituationCategory householdSituationCategory;
+
+        @Schema(description = "관심주제", example = "PHYSICAL_HEALTH")
+        private InterestTopicCategory interestTopicCategory;
+
         @Builder
-        public SignupDto(String userid, String password, String username, LocalDate birth, String gender) {
+        public SignupDto(String userid, String password, String username, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, InterestTopicCategory interestTopicCategory) {
             this.userid = userid;
             this.password = password;
             this.username = username;
+            this.email = email;
+            this.phone = phone;
             this.birth = birth;
             this.gender = gender;
+            this.householdSituationCategory = householdSituationCategory;
+            this.interestTopicCategory = interestTopicCategory;
         }
 
         public static SignupDto encodePassword(SignupDto signupDto, String encodedPassword) {
@@ -56,8 +74,12 @@ public class AuthDTO {
             newSignupDto.userid = signupDto.getUserid();
             newSignupDto.password = encodedPassword;
             newSignupDto.username = signupDto.getUsername();
+            newSignupDto.email = signupDto.getEmail();
+            newSignupDto.phone = signupDto.getPhone();
             newSignupDto.birth = signupDto.getBirth();
             newSignupDto.gender = signupDto.getGender();
+            newSignupDto.householdSituationCategory = signupDto.getHouseholdSituationCategory();
+            newSignupDto.interestTopicCategory = signupDto.getInterestTopicCategory();
             return newSignupDto;
         }
     }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
@@ -2,13 +2,13 @@ package com.projectbusan.bokjido.entity;
 
 import com.projectbusan.bokjido.dto.AuthDTO;
 import com.projectbusan.bokjido.enums.HouseholdSituationCategory;
-import com.projectbusan.bokjido.enums.InterestTopicCategory;
 import com.projectbusan.bokjido.role.Role;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 
 @Data
 @Builder
@@ -19,7 +19,8 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
+//            (strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String userid;
@@ -39,8 +40,7 @@ public class User {
     @Enumerated(EnumType.STRING)
     private HouseholdSituationCategory householdSituationCategory;
 
-    @Enumerated(EnumType.STRING)
-    private InterestTopicCategory interestTopicCategory;
+    private String interestTopicCategory;
 
     private Role role;
 
@@ -49,7 +49,7 @@ public class User {
     private LocalDateTime modify_date;
 
     @Builder
-    public User(Long id, String userid, String username, String password, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, InterestTopicCategory interestTopicCategory, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
+    public User(Long id, String userid, String username, String password, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, String interestTopicCategory, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
         this.id = id;
         this.userid = userid;
         this.username = username;
@@ -75,7 +75,7 @@ public class User {
                 .birth(signupDto.getBirth())
                 .gender(signupDto.getGender())
                 .householdSituationCategory(signupDto.getHouseholdSituationCategory())
-                .interestTopicCategory(signupDto.getInterestTopicCategory())
+                .interestTopicCategory(Arrays.toString(signupDto.getInterestTopicCategory()))
                 .role(Role.USER)
                 .create_date(LocalDateTime.now())
                 .build();

--- a/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
@@ -1,6 +1,8 @@
 package com.projectbusan.bokjido.entity;
 
 import com.projectbusan.bokjido.dto.AuthDTO;
+import com.projectbusan.bokjido.enums.HouseholdSituationCategory;
+import com.projectbusan.bokjido.enums.InterestTopicCategory;
 import com.projectbusan.bokjido.role.Role;
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,9 +28,19 @@ public class User {
 
     private String password;
 
+    private String email;
+
+    private String phone;
+
     private LocalDate birth;
 
     private String gender;
+
+    @Enumerated(EnumType.STRING)
+    private HouseholdSituationCategory householdSituationCategory;
+
+    @Enumerated(EnumType.STRING)
+    private InterestTopicCategory interestTopicCategory;
 
     private Role role;
 
@@ -37,13 +49,17 @@ public class User {
     private LocalDateTime modify_date;
 
     @Builder
-    public User(Long id, String userid, String username, String password, LocalDate birth, String gender, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
+    public User(Long id, String userid, String username, String password, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, InterestTopicCategory interestTopicCategory, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
         this.id = id;
         this.userid = userid;
         this.username = username;
         this.password = password;
+        this.email = email;
+        this.phone = phone;
         this.birth = birth;
         this.gender = gender;
+        this.householdSituationCategory = householdSituationCategory;
+        this.interestTopicCategory = interestTopicCategory;
         this.role = role;
         this.create_date = create_date;
         this.modify_date = modify_date;
@@ -54,8 +70,12 @@ public class User {
                 .userid(signupDto.getUserid())
                 .password(signupDto.getPassword())
                 .username(signupDto.getUsername())
+                .email(signupDto.getEmail())
+                .phone(signupDto.getPhone())
                 .birth(signupDto.getBirth())
                 .gender(signupDto.getGender())
+                .householdSituationCategory(signupDto.getHouseholdSituationCategory())
+                .interestTopicCategory(signupDto.getInterestTopicCategory())
                 .role(Role.USER)
                 .create_date(LocalDateTime.now())
                 .build();

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/UserService.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
     }
 
     // <<-- 전체 회원 조회 -->>
-    public List<User> findUsers() {
+    public List<User> loadAll() {
         return userRepository.findAll();
     }
 

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/UserService.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/UserService.java
@@ -9,9 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +24,13 @@ public class UserService {
     @Transactional
     public void register(AuthDTO.SignupDto signupDto) {
         validateDuplicateUser(signupDto.getUserid()); // 중복 회원 검증
+
         User user = User.register(signupDto);
+
+        if (signupDto.getInterestTopicCategory() != null) {
+            user.setInterestTopicCategory(Arrays.toString(signupDto.getInterestTopicCategory()));
+        }
+
         userRepository.save(user);
     }
 
@@ -40,11 +44,17 @@ public class UserService {
     }
 
     // <<-- 전체 회원 조회 -->>
-    public List<User> loadAll() {
+    public List<User> getAll() {
         return userRepository.findAll();
     }
 
-    public Optional<User> findOne(String userId) {
-        return userRepository.findByUserid(userId);
+    public List<String> findInterestTopic(Long id) {
+        Optional<User> user = userRepository.findById(id);
+        String interestTopic = user.get().getInterestTopicCategory();
+        if (interestTopic != null) {
+            String[] interestArray = interestTopic.substring(1, interestTopic.length() -1).split(", ");
+            return Arrays.asList(interestArray);
+        }
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
### 관련된 이슈
#23 

### 변경 사항
- User Table에 이메일 주소, 전화번호, 관심주제, 가구상황을 입력 받아 저장할 수 있도록 변경

### 구현한 API
- 유저 전체 조회 `GET api/auth/loadall`
- 해당 유저 관심주제 조회 `GET api/auth/load/{id}`

<br>

Swagger를 통해 명세 했으며, 테스트 완료