### PR TITLE
Feat[#21] 복지서비스 맞춤 추천 API 구현

### DIFF
--- a/bokjido/src/main/java/com/projectbusan/bokjido/controller/BenefitController.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/controller/BenefitController.java
@@ -44,6 +44,9 @@ public class BenefitController {
     @Operation(summary = "복지 서비스 사용자 맞춤 조회")
     @GetMapping("/user/service")
     public ResponseEntity<Page<BenefitMainResponseDTO>> getServiceByUser(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        if(userDetails == null){
+            return ResponseEntity.ok(benefitsService.getServiceByRandom(pageable));
+        }
         return ResponseEntity.ok(benefitsService.getServiceByUser(userDetails.getUser(), pageable));
     }
 

--- a/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/dto/AuthDTO.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 public class AuthDTO {
     @Getter
@@ -49,6 +48,9 @@ public class AuthDTO {
         @Schema(description = "성별", example = "남")
         private String gender;
 
+        @Schema(description = "주소", example = "서울특별시 중구 세종대로 110 (태평로1가)")
+        private String address;
+
         @Schema(description = "가구상황", example = "LOW_INCOME")
         private HouseholdSituationCategory householdSituationCategory;
 
@@ -56,7 +58,7 @@ public class AuthDTO {
         private String[] interestTopicCategory;
 
         @Builder
-        public SignupDto(String userid, String password, String username, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, String[] interestTopicCategory) {
+        public SignupDto(String userid, String password, String username, String email, String phone, LocalDate birth, String gender, String address, HouseholdSituationCategory householdSituationCategory, String[] interestTopicCategory) {
             this.userid = userid;
             this.password = password;
             this.username = username;
@@ -64,6 +66,7 @@ public class AuthDTO {
             this.phone = phone;
             this.birth = birth;
             this.gender = gender;
+            this.address = address;
             this.householdSituationCategory = householdSituationCategory;
             this.interestTopicCategory = interestTopicCategory;
         }
@@ -77,6 +80,7 @@ public class AuthDTO {
             newSignupDto.phone = signupDto.getPhone();
             newSignupDto.birth = signupDto.getBirth();
             newSignupDto.gender = signupDto.getGender();
+            newSignupDto.address = signupDto.getAddress();
             newSignupDto.householdSituationCategory = signupDto.getHouseholdSituationCategory();
             newSignupDto.interestTopicCategory = signupDto.getInterestTopicCategory();
             return newSignupDto;

--- a/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/entity/User.java
@@ -37,6 +37,8 @@ public class User {
 
     private String gender;
 
+    private String address;
+
     @Enumerated(EnumType.STRING)
     private HouseholdSituationCategory householdSituationCategory;
 
@@ -49,7 +51,7 @@ public class User {
     private LocalDateTime modify_date;
 
     @Builder
-    public User(Long id, String userid, String username, String password, String email, String phone, LocalDate birth, String gender, HouseholdSituationCategory householdSituationCategory, String interestTopicCategory, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
+    public User(Long id, String userid, String username, String password, String email, String phone, LocalDate birth, String gender, String address, HouseholdSituationCategory householdSituationCategory, String interestTopicCategory, Role role, LocalDateTime create_date, LocalDateTime modify_date) {
         this.id = id;
         this.userid = userid;
         this.username = username;
@@ -58,6 +60,7 @@ public class User {
         this.phone = phone;
         this.birth = birth;
         this.gender = gender;
+        this.address = address;
         this.householdSituationCategory = householdSituationCategory;
         this.interestTopicCategory = interestTopicCategory;
         this.role = role;
@@ -74,6 +77,7 @@ public class User {
                 .phone(signupDto.getPhone())
                 .birth(signupDto.getBirth())
                 .gender(signupDto.getGender())
+                .address(signupDto.getAddress())
                 .householdSituationCategory(signupDto.getHouseholdSituationCategory())
                 .interestTopicCategory(Arrays.toString(signupDto.getInterestTopicCategory()))
                 .role(Role.USER)

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/BenefitsService.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/BenefitsService.java
@@ -9,7 +9,9 @@ public interface BenefitsService {
     Long createService(User user, BenefitCreateRequestDTO benefitCreateRequestDTO);
     Page<BenefitMainResponseDTO> getService(BenefitRequestDTO requestDto, Pageable pageable);
     BenefitDetailsResponseDTO getServiceById(Long serviceId);
+    Page<BenefitMainResponseDTO> getServiceByRandom(Pageable pageable);
     Page<BenefitMainResponseDTO> getServiceByUser(User user, Pageable pageable);
     Long createReview(User user, BenefitReviewRequestDTO benefitReviewRequestDTO);
     Page<BenefitReviewResponseDTO> getReview(Long serviceId, Pageable pageable);
+
 }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/BenefitsServiceImpl.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/BenefitsServiceImpl.java
@@ -17,8 +17,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 @Service
@@ -87,6 +89,43 @@ public class BenefitsServiceImpl implements BenefitsService {
     public BenefitDetailsResponseDTO getServiceById(Long serviceId) {
         Benefit benefit = findBenefits(serviceId);
         return BenefitDetailsResponseDTO.toDto(benefit);
+    }
+
+    @Override
+    public Page<BenefitMainResponseDTO> getServiceByRandom(Pageable pageable) {
+        List<Benefit> benefitList = benefitsRepository.findAll();
+        if (benefitList.isEmpty()) {
+            return Page.empty();
+        }
+
+        Collections.shuffle(benefitList, new Random());
+
+        int pageSize = pageable.getPageSize();
+        int currentPage = pageable.getPageNumber();
+        int startItem = currentPage * pageSize;
+
+        List<Benefit> pageList;
+
+        if (benefitList.size() < startItem) {
+            pageList = Collections.emptyList();
+        } else {
+            int toIndex = Math.min(startItem + pageSize, benefitList.size());
+            pageList = benefitList.subList(startItem, toIndex);
+        }
+
+        List<BenefitMainResponseDTO> benefitDtoList = new ArrayList<>();
+        for (Benefit benefit : pageList) {
+            BenefitMainResponseDTO dto = BenefitMainResponseDTO.builder()
+                    .id(benefit.getId())
+                    .name(benefit.getName())
+                    .applyTarget(benefit.getApplyTarget())
+                    .summary(benefit.getSummary())
+                    .build();
+
+            benefitDtoList.add(dto);
+        }
+
+        return new PageImpl<>(benefitDtoList, pageable, benefitList.size());
     }
 
     @Override


### PR DESCRIPTION
## 📂 관련된 이슈
#21 

## 📌 구현한 API
### 질의응답 게시물
* 복지 서비스 사용자 맞춤 조회 `GET /api/user/service`
</br>

## 📝 상세 설명
1. 로그인한 사용자와 로그인하지 않은 사용자를 구분하여 서비스를 추천하는 기능을 구현하였습니다. 
로그인한 사용자는 회원 가입 정보를 기반으로 추천하고, 반면에 로그인하지 않은 사용자에게는 랜덤한 서비스를 추천합니다.
3. 회원가입시 주소 정보를 입력받을 수 있도록 address 필드를 추가하였습니다.
4. User엔티티의 생년월일, 성별, 가구상황, 관심주제, 주소 정보를 이용해 유사도를 계산하였습니다.
5. 로그인한 사용자의 나이를 생년월일을 통해 계산하고, Benefit의 lifeCycleCategory와 비교하여 아래와 같이 판단합니다:
* 0세 이상 6세 이하: INFANT
* 7세 이상 12세 이하: CHILD
* 13세 이상 18세 이하: TEENAGER
* 19세 이상 34세 이하: YOUTH
* 35세 이상 64세 이하: MIDDLE_AGED
* 65세 이상: OLD_AGED
6. 회원가입시 받은 주소 정보의"서울"과 같은 지역명만 추출하여 지자체 서비스를 추천할 수 있게 구현하였습니다.
</br>
구현한 기능은 모두 Postman으로 테스트를 완료하였습니다 👋