### PR TITLE
Fix[#26] Feat[#30] 복지시설 필터 API 구현

### DIFF
--- a/bokjido/src/main/java/com/projectbusan/bokjido/config/CorsConfig.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.projectbusan.bokjido.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:8000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/bokjido/src/main/java/com/projectbusan/bokjido/controller/FacilityController.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/controller/FacilityController.java
@@ -68,6 +68,15 @@ public class FacilityController {
         return ResponseEntity.ok(facilityList);
     }
 
+    // <<-- 복지 시설 전체 조회 By 이름 -->>
+    @Operation(summary = "해당 이름 포함하는 시설 전체 조회")
+    @GetMapping("/search/name/{name}")
+    public @ResponseBody ResponseEntity searchByName(@PathVariable(value = "name") String name) {
+        List<Facility> facilityList = welfareFacility.searchByName(name);
+
+        return ResponseEntity.ok(facilityList);
+    }
+
     // <<-- DB에 있는 전체 복지 시설 조회 -->>
     @Operation(summary = "DB의 전체 복지 시설 조회")
     @GetMapping("/loadall")

--- a/bokjido/src/main/java/com/projectbusan/bokjido/controller/FacilityController.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/controller/FacilityController.java
@@ -50,11 +50,20 @@ public class FacilityController {
         } return new ResponseEntity(facilityList, HttpStatus.OK);
     }
 
-    // <<-- 복지 시설 단일 조회 By 주소 -->>
+    // <<-- 복지 시설 전체 조회 By 주소 -->>
     @Operation(summary = "해당 주소를 포함하는 시설 전체 조회")
-    @GetMapping("/search/{location}")
+    @GetMapping("/search/location/{location}")
     public @ResponseBody ResponseEntity searchByLocation(@PathVariable(value = "location") String location) {
         List<Facility> facilityList = welfareFacility.searchByLocation(location);
+
+        return ResponseEntity.ok(facilityList);
+    }
+
+    // <<-- 복지 시설 전체 조회 By 카테고리 -->>
+    @Operation(summary = "해당 카테고리 포함하는 시설 전체 조회")
+    @GetMapping("/search/category/{category}")
+    public @ResponseBody ResponseEntity searchByCategory(@PathVariable(value = "category") String category) {
+        List<Facility> facilityList = welfareFacility.searchByCategory(category);
 
         return ResponseEntity.ok(facilityList);
     }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/repository/FacilityRepository.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/repository/FacilityRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface FacilityRepository extends JpaRepository<Facility, Long> {
 //    @Query("SELECT f FROM facility f WHERE f.location LIKE %:searchTerm%")
     List<Facility> findFacilitiesByLocationContaining(String searchTerm);
+
+    List<Facility> findFacilitiesByCategoryContaining(String searchTerm);
 }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/repository/FacilityRepository.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/repository/FacilityRepository.java
@@ -12,4 +12,6 @@ public interface FacilityRepository extends JpaRepository<Facility, Long> {
     List<Facility> findFacilitiesByLocationContaining(String searchTerm);
 
     List<Facility> findFacilitiesByCategoryContaining(String searchTerm);
+
+    List<Facility> findFacilitiesByNameContaining(String searchTerm);
 }

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/WelfareFacility.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/WelfareFacility.java
@@ -48,6 +48,10 @@ public class WelfareFacility {
         return facilityRepository.findFacilitiesByLocationContaining(searchTerm);
     }
 
+    public List<Facility> searchByCategory(String searchTerm) {
+        return facilityRepository.findFacilitiesByCategoryContaining(searchTerm);
+    }
+
     // <<-- 전체 복지 건물 조회 -->>
     public List<Facility> loadAll() { return facilityRepository.findAll(); }
 

--- a/bokjido/src/main/java/com/projectbusan/bokjido/service/WelfareFacility.java
+++ b/bokjido/src/main/java/com/projectbusan/bokjido/service/WelfareFacility.java
@@ -52,6 +52,10 @@ public class WelfareFacility {
         return facilityRepository.findFacilitiesByCategoryContaining(searchTerm);
     }
 
+    public List<Facility> searchByName(String searchTerm) {
+        return facilityRepository.findFacilitiesByNameContaining(searchTerm);
+    }
+
     // <<-- 전체 복지 건물 조회 -->>
     public List<Facility> loadAll() { return facilityRepository.findAll(); }
 


### PR DESCRIPTION
## 📂 관련된 이슈
#26
#30 


## 📌 구현한 API
### 시설 조회
* 복지 시설 카테고리 별 조회 `GET /api/facility/search/category/{category}`
* 복지 시설 키워드 별 조회 ` GET /api/facility/search/name/{name}`
</br>

## 🔧 수정 사항
### 시설 조회
* 복지 시설 주소 별 조회 시 API 요청 주소 수정
기존 `GET /api/facility/search/{location}` ->
`GET /api/facility/search/location/{location}` 으로 변경

* 프론트와 연동 시 CORS정책으로 API요청이 막히는 현상으로 Config 파일 추가

## 📝 상세 설명
1. 시설 조회 시 카테고리를 포함하는 시설을 조회하는 기능을 추가하였습니다.
2. 시설 조회 시 키워드를 포함하는 시설을 조회하는 기능을 추가하였습니다.
3. 주소를 통한 시설 조회 시 API 매핑 URL을 수정하였습니다.
     -> 카테고리 조회와 키워드 조회 모두 같은 요청 URL에 파라미터만 다르게 하면 모두 String 값이기때문에 주소검색인지 카테고리검색인지 인식하지 못하여 오류 발생
</br>
구현한 기능은 모두 Swagger로 테스트를 완료하였습니다